### PR TITLE
Return incomplete tasks in InMemoryAsyncQueryable implementation

### DIFF
--- a/src/EntityFramework.Testing/InMemoryAsyncQueryProvider.cs
+++ b/src/EntityFramework.Testing/InMemoryAsyncQueryProvider.cs
@@ -114,9 +114,10 @@ namespace EntityFramework.Testing
         /// <param name="expression">The expression tree.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The result task.</returns>
-        public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
+        public async Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
         {
-            return Task.FromResult(this.Execute(expression));
+            await Task.Yield();
+            return this.Execute(expression);
         }
 
         /// <summary>
@@ -126,9 +127,10 @@ namespace EntityFramework.Testing
         /// <param name="expression">The expression tree.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The result task.</returns>
-        public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            return Task.FromResult(this.Execute<TResult>(expression));
+            await Task.Yield();
+            return this.Execute<TResult>(expression);
         }
 #endif
         /// <summary>

--- a/src/EntityFramework.Testing/InMemoryDbAsyncEnumerator{T}.cs
+++ b/src/EntityFramework.Testing/InMemoryDbAsyncEnumerator{T}.cs
@@ -59,9 +59,10 @@ namespace EntityFramework.Testing
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The result task.</returns>
-        public Task<bool> MoveNextAsync(CancellationToken cancellationToken)
+        public async Task<bool> MoveNextAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(this.enumerator.MoveNext());
+            await Task.Yield();
+            return this.enumerator.MoveNext();
         }
 
         /// <summary>


### PR DESCRIPTION
This change is to return incomplete tasks from the async methods so the code under test would fully exercise the state machine generated for your async method implementations by configuring a continuation. Returning complete tasks will short-circuit the state machine to bypass continuation code.

For more insights see the following blog post and comments: [Async/Await and code coverage](http://bernhard-richter.blogspot.com/2014/09/asyncawait-and-code-coverage.html?showComment=1413895346783#c2098062875575976657)