### PR TITLE
Add return to fake DbSet add and remove operations

### DIFF
--- a/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
@@ -29,6 +29,20 @@
         }
 
         [Fact]
+        public void Can_return_entity_from_remove_set()
+        {
+            var blog = new Blog();
+            var data = new List<Blog> { blog };
+
+            var set = this.GetFakeDbSet().SetupData(data);
+
+            var result = set.Remove(blog);
+
+            Assert.NotNull(result);
+            Assert.Equal(blog, result);
+        }
+
+        [Fact]
         public void Can_removeRange_sets()
         {
             var blog = new Blog();
@@ -44,6 +58,22 @@
             var result = set.ToList();
 
             Assert.Equal(1, result.Count);
+        }
+
+        [Fact]
+        public void Can_return_entities_from_removeRange_sets()
+        {
+            var blog = new Blog();
+            var blog2 = new Blog();
+            var range = new List<Blog> { blog, blog2 };
+            var data = new List<Blog> { blog, blog2, new Blog() };
+
+            var set = this.GetFakeDbSet().SetupData(data);
+
+            var result = set.RemoveRange(range);
+
+            Assert.NotNull(result);
+            Assert.Equal(range, result);
         }
 
         [Fact]
@@ -63,6 +93,20 @@
         }
 
         [Fact]
+        public void Can_return_entity_from_add_set()
+        {
+            var blog = new Blog();
+            var data = new List<Blog> { };
+
+            var set = this.GetFakeDbSet().SetupData(data);
+
+            var result = set.Add(blog);
+
+            Assert.NotNull(result);
+            Assert.Equal(blog, result);
+        }
+
+        [Fact]
         public void Can_addRange_sets()
         {
             var data = new List<Blog> { new Blog(), new Blog() };
@@ -75,6 +119,21 @@
             var result = set.ToList();
 
             Assert.Equal(3, result.Count);
+        }
+
+        [Fact]
+        public void Can_return_entities_from_addRange_sets()
+        {
+            var blog = new Blog();
+            var blog2 = new Blog();
+            var range = new List<Blog> { blog, blog2 };
+
+            var set = this.GetFakeDbSet().SetupData();
+
+            var result = set.AddRange(range);
+
+            Assert.NotNull(result);
+            Assert.Equal(range, result);
         }
 
         [Fact]

--- a/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
@@ -30,6 +30,21 @@
         }
 
         [Fact]
+        public void Can_return_entity_from_remove_set()
+        {
+            var blog = new Blog();
+            var data = new List<Blog> { blog };
+
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData(data);
+
+            var result = set.Object.Remove(blog);
+
+            Assert.NotNull(result);
+            Assert.Equal(blog, result);
+        }
+
+        [Fact]
         public void Can_removeRange_sets()
         {
             var blog = new Blog();
@@ -45,6 +60,23 @@
             var result = set.Object.ToList();
 
             Assert.Equal(1, result.Count);
+        }
+
+        [Fact]
+        public void Can_return_entities_from_removeRange_sets()
+        {
+            var blog = new Blog();
+            var blog2 = new Blog();
+            var range = new List<Blog> { blog, blog2 };
+            var data = new List<Blog> { blog, blog2, new Blog() };
+
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData(data);
+
+            var result = set.Object.RemoveRange(range);
+
+            Assert.NotNull(result);
+            Assert.Equal(range, result);
         }
 
         [Fact]
@@ -64,6 +96,21 @@
         }
 
         [Fact]
+        public void Can_return_entity_from_add_set()
+        {
+            var blog = new Blog();
+            var data = new List<Blog> { };
+
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData(data);
+
+            var result = set.Object.Add(blog);
+
+            Assert.NotNull(result);
+            Assert.Equal(blog, result);
+        }
+
+        [Fact]
         public void Can_addRange_sets()
         {
             var data = new List<Blog> { new Blog(), new Blog() };
@@ -76,6 +123,22 @@
             var result = set.Object.ToList();
 
             Assert.Equal(3, result.Count);
+        }
+
+        [Fact]
+        public void Can_return_entities_from_addRange_sets()
+        {
+            var blog = new Blog();
+            var blog2 = new Blog();
+            var range = new List<Blog> { blog, blog2 };
+
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData();
+
+            var result = set.Object.AddRange(range);
+
+            Assert.NotNull(result);
+            Assert.Equal(range, result);
         }
 
         [Fact]

--- a/src/EntityFramework.Testing.Moq/MockDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.Moq/MockDbSetExtensions.cs
@@ -54,13 +54,16 @@ namespace Moq
             mock.Setup(m => m.FindAsync(It.IsAny<CancellationToken>(), It.IsAny<object[]>())).Returns<CancellationToken, object[]>((tocken, objs) => Task.Run(() => find(objs), tocken));
 #endif
 
-            mock.Setup(m => m.Remove(It.IsAny<TEntity>())).Callback<TEntity>(entity =>
+            mock.Setup(m => m.Remove(It.IsAny<TEntity>()))
+                .Callback<TEntity>(entity =>
             {
                 data.Remove(entity);
                 mock.SetupData(data, find);
-            });
+                })
+                .Returns<TEntity>(entity => entity);
 
-            mock.Setup(m => m.RemoveRange(It.IsAny<IEnumerable<TEntity>>())).Callback<IEnumerable<TEntity>>(entities =>
+            mock.Setup(m => m.RemoveRange(It.IsAny<IEnumerable<TEntity>>()))
+                .Callback<IEnumerable<TEntity>>(entities =>
             {
                 foreach (var entity in entities)
                 {
@@ -68,15 +71,19 @@ namespace Moq
                 }
 
                 mock.SetupData(data, find);
-            });
+                })
+                .Returns<IEnumerable<TEntity>>(entities => entities);
 
-            mock.Setup(m => m.Add(It.IsAny<TEntity>())).Callback<TEntity>(entity =>
+            mock.Setup(m => m.Add(It.IsAny<TEntity>()))
+                .Callback<TEntity>(entity =>
             {
                 data.Add(entity);
                 mock.SetupData(data, find);
-            });
+                })
+                .Returns<TEntity>(entity => entity);
 
-            mock.Setup(m => m.AddRange(It.IsAny<IEnumerable<TEntity>>())).Callback<IEnumerable<TEntity>>(entities =>
+            mock.Setup(m => m.AddRange(It.IsAny<IEnumerable<TEntity>>()))
+                .Callback<IEnumerable<TEntity>>(entities =>
             {
                 foreach (var entity in entities)
                 {
@@ -84,7 +91,8 @@ namespace Moq
                 };
 
                 mock.SetupData(data, find);
-            });
+                })
+                .Returns<IEnumerable<TEntity>>(entities => entities);
 
             return mock;
         }

--- a/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
@@ -35,6 +35,20 @@ namespace EntityFramework.Testing.NSubstitute.Tests
         }
 
         [Fact]
+        public void Can_return_entity_from_remove_set()
+        {
+            var blog = new Blog();
+            var data = new List<Blog> { blog };
+
+            var set = this.GetSubstituteDbSet().SetupData(data);
+
+            var result = set.Remove(blog);
+
+            Assert.NotNull(result);
+            Assert.Equal(blog, result);
+        }
+
+        [Fact]
         public void Can_removeRange_sets()
         {
             var blog = new Blog();
@@ -49,6 +63,22 @@ namespace EntityFramework.Testing.NSubstitute.Tests
             var result = set.ToList();
 
             Assert.Equal(1, result.Count);
+        }
+
+        [Fact]
+        public void Can_return_entities_from_removeRange_sets()
+        {
+            var blog = new Blog();
+            var blog2 = new Blog();
+            var range = new List<Blog> { blog, blog2 };
+            var data = new List<Blog> { blog, blog2, new Blog() };
+
+            var set = this.GetSubstituteDbSet().SetupData(data);
+
+            var result = set.RemoveRange(range);
+
+            Assert.NotNull(result);
+            Assert.Equal(range, result);
         }
 
         [Fact]
@@ -67,6 +97,20 @@ namespace EntityFramework.Testing.NSubstitute.Tests
         }
 
         [Fact]
+        public void Can_return_entity_from_add_set()
+        {
+            var blog = new Blog();
+            var data = new List<Blog> { };
+
+            var set = this.GetSubstituteDbSet().SetupData(data);
+
+            var result = set.Add(blog);
+
+            Assert.NotNull(result);
+            Assert.Equal(blog, result);
+        }
+
+        [Fact]
         public void Can_addRange_sets()
         {
             var data = new List<Blog> { new Blog(), new Blog() };
@@ -78,6 +122,21 @@ namespace EntityFramework.Testing.NSubstitute.Tests
             var result = set.ToList();
 
             Assert.Equal(3, result.Count);
+        }
+
+        [Fact]
+        public void Can_return_entities_from_addRange_sets()
+        {
+            var blog = new Blog();
+            var blog2 = new Blog();
+            var range = new List<Blog> { blog, blog2 };
+
+            var set = this.GetSubstituteDbSet().SetupData();
+
+            var result = set.AddRange(range);
+
+            Assert.NotNull(result);
+            Assert.Equal(range, result);
         }
 
         [Fact]

--- a/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
@@ -57,7 +57,7 @@ namespace NSubstitute
             dbSet.FindAsync(Arg.Any<CancellationToken>(), Arg.Any<object[]>()).Returns(new Func<CallInfo, Task<TEntity>>(info => Task.Run(() => find(info.Arg<object[]>()), info.Arg<CancellationToken>())));
 #endif
 
-            dbSet.Remove(Arg.Do<TEntity>(entity => data.Remove(entity)));
+            dbSet.Remove(Arg.Do<TEntity>(entity => data.Remove(entity))).Returns(args => args[0]);
 
             dbSet.RemoveRange(Arg.Do<IEnumerable<TEntity>>(entities =>
             {
@@ -65,9 +65,9 @@ namespace NSubstitute
                 {
                     data.Remove(entity);
                 }
-            }));
+            })).Returns(args => args[0]);
 
-            dbSet.Add(Arg.Do<TEntity>(data.Add));
+            dbSet.Add(Arg.Do<TEntity>(data.Add)).Returns(args => args[0]);
 
             dbSet.AddRange(Arg.Do<IEnumerable<TEntity>>(entities =>
             {
@@ -75,7 +75,7 @@ namespace NSubstitute
                 {
                     data.Add(entity);
                 }
-            }));
+            })).Returns(args => args[0]);
 
             return dbSet;
         }


### PR DESCRIPTION
EF returns entities successfully added or removed from a `DbSet` via the `Add[Range]` and `Remove[Range]` methods. This commit adds the implementation and unit tests for this behaviour.

Note this behaviour was already implemented in `FakeItEasyDbSetExtensions.cs` but this lacked test coverage and was not implemented in the other two fake implementations.