### PR TITLE
Add default behaviour for `DbSet.Create` and `IQueryable.AsNoTracking`

### DIFF
--- a/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
@@ -157,7 +157,7 @@
             {
                 new Blog { BlogId = 1 },
                 new Blog { BlogId = 2 },
-                new Blog { BlogId = 3}
+                new Blog { BlogId = 3 }
             };
 
             var set = this.GetFakeDbSet()
@@ -180,14 +180,30 @@
         }
 
         [Fact]
-        public void Can_create_generic_entity()
+        public void Can_specify_include()
         {
             var set = this.GetFakeDbSet()
-                .SetupData();
+                .SetupData(new List<Blog> { new Blog() });
 
-            Assert.IsType<FeaturedBlog>(set.Create<FeaturedBlog>());
+            var result = set
+                .Include(b => b.Posts)
+                .ToList();
+
+            Assert.Equal(1, result.Count);
         }
 
+        [Fact]
+        public void Can_specify_asNoTracking()
+        {
+            var set = this.GetFakeDbSet()
+                .SetupData(new List<Blog> { new Blog() });
+
+            var result = set
+                .AsNoTracking()
+                .ToList();
+
+            Assert.Equal(1, result.Count);
+        }
 
         private DbSet<Blog> GetFakeDbSet()
         {

--- a/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
@@ -180,6 +180,40 @@
         }
 
         [Fact]
+        public void Can_specify_create()
+        {
+            var expected = new Blog();
+
+            var set = this.GetFakeDbSet()
+                .SetupData()
+                .SetupCreate<Blog>(() => expected);
+
+            Assert.Equal<Blog>(expected, set.Create());
+        }
+
+        [Fact]
+        public void Can_create_generic_entity()
+        {
+            var set = this.GetFakeDbSet()
+                .SetupData()
+                .SetupCreate<Blog, FeaturedBlog>();
+
+            Assert.IsType<FeaturedBlog>(set.Create<FeaturedBlog>());
+        }
+
+        [Fact]
+        public void Can_specify_generic_create()
+        {
+            var expected = new FeaturedBlog();
+
+            var set = this.GetFakeDbSet()
+                .SetupData()
+                .SetupCreate<Blog, FeaturedBlog>(() => expected);
+
+            Assert.Equal<Blog>(expected, set.Create<FeaturedBlog>());
+        }
+
+        [Fact]
         public void Can_specify_include()
         {
             var set = this.GetFakeDbSet()

--- a/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.FakeItEasy.Tests/ManipulationTests.cs
@@ -170,6 +170,24 @@
             Assert.Equal(1, result.BlogId);
         }
 #endif
+        [Fact]
+        public void Can_create_entity()
+        {
+            var set = this.GetFakeDbSet()
+                .SetupData();
+
+            Assert.IsType<Blog>(set.Create());
+        }
+
+        [Fact]
+        public void Can_create_generic_entity()
+        {
+            var set = this.GetFakeDbSet()
+                .SetupData();
+
+            Assert.IsType<FeaturedBlog>(set.Create<FeaturedBlog>());
+        }
+
 
         private DbSet<Blog> GetFakeDbSet()
         {
@@ -178,6 +196,10 @@
 #else
             return A.Fake<DbSet<Blog>>(o => o.Implements(typeof(IQueryable<Blog>)).Implements(typeof(IDbAsyncEnumerable<Blog>)));
 #endif
+        }
+
+        public class FeaturedBlog : Blog
+        {
         }
 
         public class Blog

--- a/src/EntityFramework.Testing.FakeItEasy/FakeItEasyDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.FakeItEasy/FakeItEasyDbSetExtensions.cs
@@ -46,7 +46,7 @@ namespace FakeItEasy
             A.CallTo(() => ((IDbAsyncEnumerable<TEntity>)dbSet).GetAsyncEnumerator()).ReturnsLazily(info => query.GetAsyncEnumerator());
 #endif
             A.CallTo(() => dbSet.AsNoTracking()).Returns(dbSet);
-            A.CallTo(() => dbSet.Create()).ReturnsLazily(info => query.Create());
+            SetupCreate(dbSet);
             A.CallTo(() => dbSet.Include(A<string>._)).Returns(dbSet);
             A.CallTo(() => dbSet.Find(A<object[]>._)).ReturnsLazily<TEntity, object[]>(objs => find(objs));
 
@@ -87,6 +87,36 @@ namespace FakeItEasy
                 return entities;
             });
 
+            return dbSet;
+        }
+
+        /// <summary>
+        /// Sets up the Create function on the <see cref="Mock{T}"/>.
+        /// </summary>    
+        /// <param name="mock">The <see cref="Mock{T}"/>.</param>
+        /// <param name="create">The create action.</param>
+        /// <returns>The updated <see cref="Mock{T}"/>.</returns>
+        public static DbSet<TEntity> SetupCreate<TEntity>(this DbSet<TEntity> dbSet, Func<TEntity> create = null)
+             where TEntity : class
+        {
+            create = create ?? InMemoryAsyncQueryable<TEntity>.Create;
+            A.CallTo(() => dbSet.Create()).ReturnsLazily(info => create());
+            return dbSet;
+        }
+
+        /// <summary>
+        /// Sets up the generic Create function on the <see cref="Mock{T}"/>.
+        /// </summary>    
+        /// <typeparam name="TDerivedEntity">The type of entity to create.</typeparam>    
+        /// <param name="mock">The <see cref="Mock{T}"/>.</param>
+        /// <param name="create">The create action.</param>
+        /// <returns>The updated <see cref="Mock{T}"/>.</returns>
+        public static DbSet<TEntity> SetupCreate<TEntity, TDerivedEntity>(this DbSet<TEntity> dbSet, Func<TDerivedEntity> create = null)
+            where TEntity : class
+            where TDerivedEntity : class, TEntity
+        {
+            create = create ?? InMemoryAsyncQueryable<TEntity>.Create<TDerivedEntity>;
+            A.CallTo(() => dbSet.Create<TDerivedEntity>()).ReturnsLazily(info => create());
             return dbSet;
         }
     }

--- a/src/EntityFramework.Testing.FakeItEasy/FakeItEasyDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.FakeItEasy/FakeItEasyDbSetExtensions.cs
@@ -45,6 +45,7 @@ namespace FakeItEasy
 #if !NET40
             A.CallTo(() => ((IDbAsyncEnumerable<TEntity>)dbSet).GetAsyncEnumerator()).ReturnsLazily(info => query.GetAsyncEnumerator());
 #endif
+            A.CallTo(() => dbSet.AsNoTracking()).Returns(dbSet);
             A.CallTo(() => dbSet.Create()).ReturnsLazily(info => query.Create());
             A.CallTo(() => dbSet.Include(A<string>._)).Returns(dbSet);
             A.CallTo(() => dbSet.Find(A<object[]>._)).ReturnsLazily<TEntity, object[]>(objs => find(objs));

--- a/src/EntityFramework.Testing.FakeItEasy/FakeItEasyDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.FakeItEasy/FakeItEasyDbSetExtensions.cs
@@ -45,6 +45,7 @@ namespace FakeItEasy
 #if !NET40
             A.CallTo(() => ((IDbAsyncEnumerable<TEntity>)dbSet).GetAsyncEnumerator()).ReturnsLazily(info => query.GetAsyncEnumerator());
 #endif
+            A.CallTo(() => dbSet.Create()).ReturnsLazily(info => query.Create());
             A.CallTo(() => dbSet.Include(A<string>._)).Returns(dbSet);
             A.CallTo(() => dbSet.Find(A<object[]>._)).ReturnsLazily<TEntity, object[]>(objs => find(objs));
 

--- a/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
@@ -162,7 +162,7 @@
             {
                 new Blog { BlogId = 1 },
                 new Blog { BlogId = 2 },
-                new Blog { BlogId = 3}
+                new Blog { BlogId = 3 }
             };
 
             var set = new Mock<DbSet<Blog>>()
@@ -186,12 +186,29 @@
         }
 
         [Fact]
-        public void Can_create_generic_entity()
+        public void Can_specify_include()
         {
             var set = new Mock<DbSet<Blog>>()
-                .SetupData();
+                .SetupData(new List<Blog> { new Blog() });
 
-            Assert.IsType<FeaturedBlog>(set.Object.Create<FeaturedBlog>());
+            var result = set.Object
+                .Include(b => b.Posts)
+                .ToList();
+
+            Assert.Equal(1, result.Count);
+        }
+
+        [Fact]
+        public void Can_specify_asNoTracking()
+        {
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData(new List<Blog> { new Blog() });
+
+            var result = set.Object
+                .AsNoTracking()
+                .ToList();
+
+            Assert.Equal(1, result.Count);
         }
 
         public class FeaturedBlog : Blog

--- a/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
@@ -186,6 +186,40 @@
         }
 
         [Fact]
+        public void Can_specify_create()
+        {
+            var expected = new Blog();
+
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData()
+                .SetupCreate<Blog>(() => expected);
+
+            Assert.Equal<Blog>(expected, set.Object.Create());
+        }
+
+        [Fact]
+        public void Can_create_generic_entity()
+        {
+            var set = new Mock<DbSet<Blog>>()
+               .SetupData()
+               .SetupCreate<Blog, FeaturedBlog>();
+
+            Assert.IsType<FeaturedBlog>(set.Object.Create<FeaturedBlog>());
+        }
+
+        [Fact]
+        public void Can_specify_generic_create()
+        {
+            var expected = new FeaturedBlog();
+
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData()
+                .SetupCreate<Blog, FeaturedBlog>(() => expected);
+
+            Assert.Equal<Blog>(expected, set.Object.Create<FeaturedBlog>());
+        }
+
+        [Fact]
         public void Can_specify_include()
         {
             var set = new Mock<DbSet<Blog>>()

--- a/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.Moq.Tests/ManipulationTests.cs
@@ -176,6 +176,28 @@
         }
 #endif
 
+        [Fact]
+        public void Can_create_entity()
+        {
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData();
+
+            Assert.IsType<Blog>(set.Object.Create());
+        }
+
+        [Fact]
+        public void Can_create_generic_entity()
+        {
+            var set = new Mock<DbSet<Blog>>()
+                .SetupData();
+
+            Assert.IsType<FeaturedBlog>(set.Object.Create<FeaturedBlog>());
+        }
+
+        public class FeaturedBlog : Blog
+        {
+        }
+
         public class Blog
         {
             public int BlogId { get; set; }

--- a/src/EntityFramework.Testing.Moq/MoqDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.Moq/MoqDbSetExtensions.cs
@@ -46,9 +46,9 @@ namespace Moq
 #if !NET40
             mock.As<IDbAsyncEnumerable<TEntity>>().Setup(m => m.GetAsyncEnumerator()).Returns(query.GetAsyncEnumerator);
 #endif
+            mock.Setup(m => m.Create()).Returns(query.Create);
             mock.Setup(m => m.Include(It.IsAny<string>())).Returns(mock.Object);
             mock.Setup(m => m.Find(It.IsAny<object[]>())).Returns<object[]>(find);
-
 #if !NET40
             mock.Setup(m => m.FindAsync(It.IsAny<object[]>())).Returns<object[]>(objs => Task.Run(() => find(objs)));
             mock.Setup(m => m.FindAsync(It.IsAny<CancellationToken>(), It.IsAny<object[]>())).Returns<CancellationToken, object[]>((tocken, objs) => Task.Run(() => find(objs), tocken));

--- a/src/EntityFramework.Testing.Moq/MoqDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.Moq/MoqDbSetExtensions.cs
@@ -47,7 +47,7 @@ namespace Moq
             mock.As<IDbAsyncEnumerable<TEntity>>().Setup(m => m.GetAsyncEnumerator()).Returns(query.GetAsyncEnumerator);
 #endif
             mock.Setup(m => m.AsNoTracking()).Returns(mock.Object);
-            mock.Setup(m => m.Create()).Returns(query.Create);
+            SetupCreate(mock);
             mock.Setup(m => m.Include(It.IsAny<string>())).Returns(mock.Object);
             mock.Setup(m => m.Find(It.IsAny<object[]>())).Returns<object[]>(find);
 #if !NET40
@@ -95,6 +95,36 @@ namespace Moq
                 })
                 .Returns<IEnumerable<TEntity>>(entities => entities);
 
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up the Create function on the <see cref="Mock{T}"/>.
+        /// </summary>    
+        /// <param name="mock">The <see cref="Mock{T}"/>.</param>
+        /// <param name="create">The create action.</param>
+        /// <returns>The updated <see cref="Mock{T}"/>.</returns>
+        public static Mock<DbSet<TEntity>> SetupCreate<TEntity>(this Mock<DbSet<TEntity>> mock, Func<TEntity> create = null)
+             where TEntity : class
+        {
+            create = create ?? InMemoryAsyncQueryable<TEntity>.Create;
+            mock.Setup(m => m.Create()).Returns(create);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up the generic Create function on the <see cref="Mock{T}"/>.
+        /// </summary>    
+        /// <typeparam name="TDerivedEntity">The type of entity to create.</typeparam>    
+        /// <param name="mock">The <see cref="Mock{T}"/>.</param>
+        /// <param name="create">The create action.</param>
+        /// <returns>The updated <see cref="Mock{T}"/>.</returns>
+        public static Mock<DbSet<TEntity>> SetupCreate<TEntity, TDerivedEntity>(this Mock<DbSet<TEntity>> mock, Func<TDerivedEntity> create = null)
+            where TEntity : class
+            where TDerivedEntity : class, TEntity
+        {
+            create = create ?? InMemoryAsyncQueryable<TEntity>.Create<TDerivedEntity>;
+            mock.Setup(m => m.Create<TDerivedEntity>()).Returns(create);
             return mock;
         }
     }

--- a/src/EntityFramework.Testing.Moq/MoqDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.Moq/MoqDbSetExtensions.cs
@@ -46,6 +46,7 @@ namespace Moq
 #if !NET40
             mock.As<IDbAsyncEnumerable<TEntity>>().Setup(m => m.GetAsyncEnumerator()).Returns(query.GetAsyncEnumerator);
 #endif
+            mock.Setup(m => m.AsNoTracking()).Returns(mock.Object);
             mock.Setup(m => m.Create()).Returns(query.Create);
             mock.Setup(m => m.Include(It.IsAny<string>())).Returns(mock.Object);
             mock.Setup(m => m.Find(It.IsAny<object[]>())).Returns<object[]>(find);

--- a/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
@@ -174,6 +174,24 @@ namespace EntityFramework.Testing.NSubstitute.Tests
         }
 #endif
 
+        [Fact]
+        public void Can_create_entity()
+        {
+            var set = this.GetSubstituteDbSet()
+                .SetupData();
+
+            Assert.IsType<Blog>(set.Create());
+        }
+
+        [Fact]
+        public void Can_create_generic_entity()
+        {
+            var set = this.GetSubstituteDbSet()
+                .SetupData();
+
+            Assert.IsType<FeaturedBlog>(set.Create<FeaturedBlog>());
+        }
+
         private DbSet<Blog> GetSubstituteDbSet()
         {
 #if NET40
@@ -181,6 +199,10 @@ namespace EntityFramework.Testing.NSubstitute.Tests
 #else
             return Substitute.For<DbSet<Blog>, IQueryable<Blog>, IDbAsyncEnumerable<Blog>>();
 #endif
+        }
+
+        public class FeaturedBlog : Blog
+        {
         }
 
         public class Blog

--- a/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
@@ -184,6 +184,40 @@ namespace EntityFramework.Testing.NSubstitute.Tests
         }
 
         [Fact]
+        public void Can_specify_create()
+        {
+            var expected = new Blog();
+
+            var set = this.GetSubstituteDbSet()
+                .SetupData()
+                .SetupCreate<Blog>(() => expected);
+
+            Assert.Equal<Blog>(expected, set.Create());
+        }
+
+        [Fact]
+        public void Can_create_generic_entity()
+        {
+            var set = this.GetSubstituteDbSet()
+                .SetupData()
+                .SetupCreate<Blog, FeaturedBlog>();
+
+            Assert.IsType<FeaturedBlog>(set.Create<FeaturedBlog>());
+        }
+
+        [Fact]
+        public void Can_specify_generic_create()
+        {
+            var expected = new FeaturedBlog();
+
+            var set = this.GetSubstituteDbSet()
+                .SetupData()
+                .SetupCreate<Blog, FeaturedBlog>(() => expected);
+
+            Assert.Equal<Blog>(expected, set.Create<FeaturedBlog>());
+        }
+
+        [Fact]
         public void Can_specify_include()
         {
             var set = this.GetSubstituteDbSet()

--- a/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
+++ b/src/EntityFramework.Testing.NSubstitute.Tests/ManipulationTests.cs
@@ -160,7 +160,7 @@ namespace EntityFramework.Testing.NSubstitute.Tests
             {
                 new Blog { BlogId = 1 },
                 new Blog { BlogId = 2 },
-                new Blog { BlogId = 3}
+                new Blog { BlogId = 3 }
             };
 
             var set = this.GetSubstituteDbSet()
@@ -184,12 +184,29 @@ namespace EntityFramework.Testing.NSubstitute.Tests
         }
 
         [Fact]
-        public void Can_create_generic_entity()
+        public void Can_specify_include()
         {
             var set = this.GetSubstituteDbSet()
-                .SetupData();
+                .SetupData(new List<Blog> { new Blog() });
 
-            Assert.IsType<FeaturedBlog>(set.Create<FeaturedBlog>());
+            var result = set
+                .Include(b => b.Posts)
+                .ToList();
+
+            Assert.Equal(1, result.Count);
+        }
+
+        [Fact]
+        public void Can_specify_asNoTracking()
+        {
+            var set = this.GetSubstituteDbSet()
+                .SetupData(new List<Blog> { new Blog() });
+
+            var result = set
+                .AsNoTracking()
+                .ToList();
+
+            Assert.Equal(1, result.Count);
         }
 
         private DbSet<Blog> GetSubstituteDbSet()

--- a/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
@@ -49,6 +49,7 @@ namespace NSubstitute
             ((IDbAsyncEnumerable<TEntity>)dbSet).GetAsyncEnumerator().Returns(info => getQuery().GetAsyncEnumerator());
 #endif
 
+            dbSet.Create().Returns(info => getQuery().Create());
             dbSet.Include(Arg.Any<string>()).Returns(dbSet);
             dbSet.Find(Arg.Any<object[]>()).Returns(new Func<CallInfo, TEntity>(info => find(info.Arg<object[]>())));
 

--- a/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
@@ -48,7 +48,7 @@ namespace NSubstitute
 #if !NET40
             ((IDbAsyncEnumerable<TEntity>)dbSet).GetAsyncEnumerator().Returns(info => getQuery().GetAsyncEnumerator());
 #endif
-
+            dbSet.AsNoTracking().Returns(dbSet);
             dbSet.Create().Returns(info => getQuery().Create());
             dbSet.Include(Arg.Any<string>()).Returns(dbSet);
             dbSet.Find(Arg.Any<object[]>()).Returns(new Func<CallInfo, TEntity>(info => find(info.Arg<object[]>())));

--- a/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
+++ b/src/EntityFramework.Testing.NSubstitute/NSubstituteDbSetExtensions.cs
@@ -49,7 +49,7 @@ namespace NSubstitute
             ((IDbAsyncEnumerable<TEntity>)dbSet).GetAsyncEnumerator().Returns(info => getQuery().GetAsyncEnumerator());
 #endif
             dbSet.AsNoTracking().Returns(dbSet);
-            dbSet.Create().Returns(info => getQuery().Create());
+            SetupCreate(dbSet);
             dbSet.Include(Arg.Any<string>()).Returns(dbSet);
             dbSet.Find(Arg.Any<object[]>()).Returns(new Func<CallInfo, TEntity>(info => find(info.Arg<object[]>())));
 
@@ -78,6 +78,36 @@ namespace NSubstitute
                 }
             })).Returns(args => args[0]);
 
+            return dbSet;
+        }
+
+        /// <summary>
+        /// Sets up the Create function on the <see cref="Mock{T}"/>.
+        /// </summary>    
+        /// <param name="mock">The <see cref="Mock{T}"/>.</param>
+        /// <param name="create">The create action.</param>
+        /// <returns>The updated <see cref="Mock{T}"/>.</returns>
+        public static DbSet<TEntity> SetupCreate<TEntity>(this DbSet<TEntity> dbSet, Func<TEntity> create = null)
+             where TEntity : class
+        {
+            create = create ?? InMemoryAsyncQueryable<TEntity>.Create;
+            dbSet.Create().Returns(info => create());
+            return dbSet;
+        }
+
+        /// <summary>
+        /// Sets up the generic Create function on the <see cref="Mock{T}"/>.
+        /// </summary>    
+        /// <typeparam name="TDerivedEntity">The type of entity to create.</typeparam>    
+        /// <param name="mock">The <see cref="Mock{T}"/>.</param>
+        /// <param name="create">The create action.</param>
+        /// <returns>The updated <see cref="Mock{T}"/>.</returns>
+        public static DbSet<TEntity> SetupCreate<TEntity, TDerivedEntity>(this DbSet<TEntity> dbSet, Func<TDerivedEntity> create = null)
+            where TEntity : class
+            where TDerivedEntity : class, TEntity
+        {
+            create = create ?? InMemoryAsyncQueryable<TEntity>.Create<TDerivedEntity>;
+            dbSet.Create<TDerivedEntity>().Returns(info => create());
             return dbSet;
         }
     }

--- a/src/EntityFramework.Testing/InMemoryAsyncQueryable{T}.cs
+++ b/src/EntityFramework.Testing/InMemoryAsyncQueryable{T}.cs
@@ -91,6 +91,27 @@ namespace EntityFramework.Testing
         }
 
         /// <summary>
+        /// Creates a new instance of an entity for the type of this set.
+        /// Note that this instance is NOT added or attached to the set.
+        /// </summary>
+        /// <returns>The entity instance.</returns>
+        public T Create()
+        {
+            return Activator.CreateInstance<T>();
+        }
+
+        /// <summary>
+        /// Creates a new instance of an entity for the type of this set or for a type derived from the type of this set.
+        /// Note that this instance is NOT added or attached to the set.
+        /// </summary>
+        /// <typeparam name="TDerivedEntity">The type of entity to create.</typeparam>
+        /// <returns>The entity instance.</returns>
+        public TDerivedEntity Create<TDerivedEntity>()
+        {
+            return Activator.CreateInstance<TDerivedEntity>();
+        }
+
+        /// <summary>
         /// Include navigation properties.
         /// </summary>
         /// <param name="path">The property path.</param>

--- a/src/EntityFramework.Testing/InMemoryAsyncQueryable{T}.cs
+++ b/src/EntityFramework.Testing/InMemoryAsyncQueryable{T}.cs
@@ -73,6 +73,25 @@ namespace EntityFramework.Testing
         }
 
         /// <summary>
+        /// Creates a new instance of an entity for the type of this set.
+        /// </summary>
+        /// <returns>The entity instance.</returns>
+        public static T Create()
+        {
+            return Activator.CreateInstance<T>();
+        }
+
+        /// <summary>
+        /// Creates a new instance of an entity for the type of this set or for a type derived from the type of this set.    
+        /// </summary>    
+        /// <typeparam name="TDerivedEntity">The type of entity to create.</typeparam>    
+        /// <returns>The entity instance.</returns>    
+        public static TDerivedEntity Create<TDerivedEntity>()
+        {
+            return Activator.CreateInstance<TDerivedEntity>();
+        }
+
+        /// <summary>
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.</returns>
@@ -88,16 +107,6 @@ namespace EntityFramework.Testing
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();
-        }
-
-        /// <summary>
-        /// Creates a new instance of an entity for the type of this set.
-        /// Note that this instance is NOT added or attached to the set.
-        /// </summary>
-        /// <returns>The entity instance.</returns>
-        public T Create()
-        {
-            return Activator.CreateInstance<T>();
         }
 
         /// <summary>

--- a/src/EntityFramework.Testing/InMemoryAsyncQueryable{T}.cs
+++ b/src/EntityFramework.Testing/InMemoryAsyncQueryable{T}.cs
@@ -101,17 +101,6 @@ namespace EntityFramework.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of an entity for the type of this set or for a type derived from the type of this set.
-        /// Note that this instance is NOT added or attached to the set.
-        /// </summary>
-        /// <typeparam name="TDerivedEntity">The type of entity to create.</typeparam>
-        /// <returns>The entity instance.</returns>
-        public TDerivedEntity Create<TDerivedEntity>()
-        {
-            return Activator.CreateInstance<TDerivedEntity>();
-        }
-
-        /// <summary>
         /// Include navigation properties.
         /// </summary>
         /// <param name="path">The property path.</param>


### PR DESCRIPTION
This pull request adds default behaviour for the following:

- `DbSet.Create` which returns a new entity instance on each invocation.
- `IQueryable.AsNoTracking` which is a no-op but allows the call to be specified in code under test.

Please note that the overload `DbSet.Create<TDerivedEntity>` is not yet supported. 

This pull request also adds a test ensuring the expression based overload of `IQueryable.Include` can be used within code under test.